### PR TITLE
sepolicy: added appdomain.te

### DIFF
--- a/sepolicy/qti/vendor/appdomain.te
+++ b/sepolicy/qti/vendor/appdomain.te
@@ -1,0 +1,2 @@
+allow { appdomain -isolated_app_all } adsprpcd_file:dir r_dir_perms;
+allow { appdomain -isolated_app_all } public_adsprpcd_file:file r_file_perms;


### PR DESCRIPTION
This file is necessary for OnePlus camera, without this file I got build error
Ref: https://github.com/crdroidandroid/android_hardware_oplus/commit/bd2717622d71890242cb8c440d8093623e107666