### PR TITLE
Euicc: Remove duplicate hidden API whitelist

### DIFF
--- a/Euicc/Android.bp
+++ b/Euicc/Android.bp
@@ -6,6 +6,7 @@
 
 android_app {
     name: "OplusEuicc",
+    overrides: ["EuiccPolicy"],
 
     srcs: ["src/**/*.kt"],
 
@@ -23,10 +24,3 @@ android_app {
     ],
 }
 
-prebuilt_etc {
-    name: "hidden-api-whitelist-org.lineageos.euicc.xml",
-    relative_install_path: "sysconfig",
-    filename: "hidden-api-whitelist-org.lineageos.euicc.xml",
-    src: "hidden-api-whitelist-org.lineageos.euicc.xml",
-    product_specific: true,
-}


### PR DESCRIPTION
The hidden API whitelist for Euicc is now included in the main LineageOS sources.

Removed the redundant prebuilt definition from the device tree to resolve the build conflict. The device-specific OplusEuicc app will now use the generic whitelist file.

This PR fixes a build error caused by the following upstream LineageOS commit: 
https://github.com/LineageOS/android/commit/7d408383a8f199ba9a72e8a3b4314c6d848b459c